### PR TITLE
libmedia: Fix null pointer crash in secure buffer allocation..

### DIFF
--- a/media/libmedia/omx/1.0/WOmxNode.cpp
+++ b/media/libmedia/omx/1.0/WOmxNode.cpp
@@ -151,8 +151,9 @@ status_t LWOmxNode::allocateSecureBuffer(
                     hidl_handle const& outNativeHandle) {
                 fnStatus = toStatusT(status);
                 *buffer = outBuffer;
-                *native_handle = NativeHandle::create(
-                        native_handle_clone(outNativeHandle), true);
+                *native_handle = outNativeHandle == nullptr ?
+                               nullptr : NativeHandle::create(
+                               native_handle_clone(outNativeHandle), true);
             }));
     return transStatus == NO_ERROR ? fnStatus : transStatus;
 }


### PR DESCRIPTION
Add null pointer check for native_handle as it is null if
secure memory allocation fails.

Change-Id: I204ca69b9808448788c83a1ae5a642618eca8973